### PR TITLE
Version the env files for tiny and amplicon

### DIFF
--- a/environment-files/q2-perc-norm-qiime2-amplicon-2025.7.yml
+++ b/environment-files/q2-perc-norm-qiime2-amplicon-2025.7.yml
@@ -1,9 +1,9 @@
 channels:
-- https://packages.qiime2.org/qiime2/latest/tiny/passed
+- https://packages.qiime2.org/qiime2/2025.7/amplicon/released
 - conda-forge
 - bioconda
 dependencies:
-  - qiime2-tiny
+  - qiime2-amplicon
   - pip
   - pip:
     - q2-perc-norm@git+https://github.com/cduvallet/q2-perc-norm.git@master

--- a/environment-files/q2-perc-norm-qiime2-tiny-2025.7.yml
+++ b/environment-files/q2-perc-norm-qiime2-tiny-2025.7.yml
@@ -1,5 +1,5 @@
 channels:
-- https://packages.qiime2.org/qiime2/stable/tiny/released
+- https://packages.qiime2.org/qiime2/2025.7/tiny/released
 - conda-forge
 - bioconda
 dependencies:


### PR DESCRIPTION
The version files need to refer to specific QIIME 2 releases that your plugin is compatible with. We ensure your plugin is installable in these specific release environments.